### PR TITLE
feat: increase INLINE_CAP without increasing the byte size of `Repr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ version = "0.2.2"
 dependencies = [
  "bytes",
  "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -21,3 +22,9 @@ name = "serde"
 version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ keywords = ["string", "str", "volo"]
 bytes = "1"
 serde = { version = "1", optional = true, default_features = false }
 
+[dev-dependencies]
+static_assertions = { version = "1.1.0" }
+
 [features]
 default = ["std"]
 std = ["serde/std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,11 @@ use std::{
 #[derive(Clone)]
 pub struct FastStr(Repr);
 
+#[cfg(all(test, target_pointer_width = "64"))]
+mod size_asserts {
+    static_assertions::assert_eq_size!(super::FastStr, [u8; 40]); // 40 bytes
+}
+
 impl FastStr {
     #[inline]
     pub fn new<T>(text: T) -> Self
@@ -420,7 +425,7 @@ impl From<Cow<'static, str>> for FastStr {
     }
 }
 
-const INLINE_CAP: usize = 22;
+const INLINE_CAP: usize = 38;
 
 #[derive(Clone)]
 enum Repr {


### PR DESCRIPTION
`Repr` is 40 bytes so we can increase INLINE_CAP without exceeding limit.