### PR TITLE
feat: update redis to 0.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "faststr"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "bytes",
  "criterion",
@@ -384,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c580d9cbbe1d1b479e8d67cf9daf6a62c957e6846048408b80b43ac3f6af84cd"
+checksum = "3268dab7fe8f1d136b3c4367bc230383dc2c357f8e305ee898fa3beacddaf00d"
 dependencies = [
  "combine",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faststr"
-version = "0.2.17"
+version = "0.2.18"
 authors = ["Volo Team <volo@cloudwego.io>"]
 edition = "2021"
 description = "Faststr is a string library that reduces the cost of clone."
@@ -15,7 +15,7 @@ keywords = ["string", "str", "volo"]
 bytes = "1"
 serde = { version = "1", optional = true, default_features = false }
 simdutf8 = { version = "0.1", features = ["aarch64_neon"] }
-redis = { version = "0.24", optional = true, default_features = false }
+redis = { version = "0.25", optional = true, default_features = false }
 itoa = { version = "1", optional = true }
 
 [features]


### PR DESCRIPTION
`redis-rs` has released 0.25.0 yesterday. In the new version, redis has provided an method `from_owned_redis_value` which can help to reduce malloc and memcopy.

This PR updates the supported redis version to 0.25.0.