### PR TITLE
feat: support `no_std`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ jobs:
       - test-linux-aarch64
       - test-macos
       - test-windows
+      - test-no-std
       - lint
     steps:
       - run: exit 0
@@ -77,6 +78,23 @@ jobs:
         run: |
           cargo check
           cargo test
+
+  test-no-std:
+    runs-on: [self-hosted, X64]
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-none
+          - aarch64-unknown-none
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Check no_std
+        run: |
+          rustup target add ${{ matrix.target }}
+          cargo check --target ${{ matrix.target }} --no-default-features
 
   lint:
     runs-on: [self-hosted, X64]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ ryu = { version = "1", optional = true }
 
 [features]
 default = ["std"]
-std = ["serde/std"]
+std = ["serde?/std"]
 serde = ["dep:serde"]
 serde-unsafe = ["serde"]
 redis = ["dep:redis", "itoa", "ryu"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,21 @@ keywords = ["string", "str", "volo"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = "1"
+bytes = { version = "1", default-features = false }
 serde = { version = "1", optional = true, default-features = false }
-simdutf8 = { version = "0.1", features = ["aarch64_neon"] }
+simdutf8 = { version = "0.1", default-features = false, features = [
+    "aarch64_neon",
+] }
 redis = { version = "0.26", optional = true, default-features = false }
 itoa = { version = "1", optional = true }
 ryu = { version = "1", optional = true }
 
 [features]
 default = ["std"]
-std = ["serde?/std"]
-serde = ["dep:serde"]
+std = ["bytes/std", "simdutf8/std", "serde?/std"]
+serde = ["serde/alloc"]
 serde-unsafe = ["serde"]
-redis = ["dep:redis", "itoa", "ryu"]
+redis = ["std", "dep:redis", "itoa", "ryu"]
 redis-unsafe = ["redis"]
 
 [dev-dependencies]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,3 +1,4 @@
+use alloc::{string::String, vec::Vec};
 use core::fmt;
 
 #[cfg(not(feature = "serde-unsafe"))]


### PR DESCRIPTION
closes https://github.com/volo-rs/faststr/issues/12

1. `bytes` and `simdutf8` support for `no_std` makes it possible for `faststr` to support `no_std`.

2. According to https://doc.rust-lang.org/cargo/reference/features.html#dependency-features:
    > The "package-name/feature-name" syntax will also enable package-name if it is an optional dependency. Often this is not what you want. You can add a ? as in "package-name?/feature-name" which will only enable the given feature if something else enables the optional dependency.

    Changing `serde/std` to `serde?/std` decreases the library size from 159kb to 142kb on aarch64.