### PR TITLE
Support `ts-rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,7 @@ dependencies = [
  "sqlx",
  "sqlx-mysql",
  "static_assertions",
+ "ts-rs",
 ]
 
 [[package]]
@@ -1544,6 +1545,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "ts-rs"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e640d9b0964e9d39df633548591090ab92f7a4567bc31d3891af23471a3365c6"
+dependencies = [
+ "lazy_static",
+ "thiserror",
+ "ts-rs-macros",
+]
+
+[[package]]
+name = "ts-rs-macros"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e9d8656589772eeec2cf7a8264d9cda40fb28b9bc53118ceb9e8c07f8f38730"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ ryu = { version = "1", optional = true }
 rkyv = { version = "0.8", optional = true, default-features = false }
 sqlx = { version = "0.8", optional = true, default-features = false }
 sqlx-mysql = { version = "0.8", optional = true, default-features = false }
+ts-rs = { version = "10.1", optional = true, default-features = false }
 
 [features]
 default = ["std"]
@@ -34,6 +35,7 @@ redis-unsafe = ["redis"]
 rkyv = ["rkyv/alloc"]
 sqlx-mysql = ["std", "dep:sqlx", "dep:sqlx-mysql"]
 sqlx-mysql-unsafe = ["sqlx-mysql"]
+ts-rs = ["std", "dep:ts-rs"]
 
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -806,3 +806,6 @@ mod rkyv;
 
 #[cfg(feature = "sqlx-mysql")]
 mod sqlx_mysql;
+
+#[cfg(feature = "ts-rs")]
+pub mod ts_rs;

--- a/src/ts_rs.rs
+++ b/src/ts_rs.rs
@@ -1,0 +1,47 @@
+use crate::FastStr;
+
+impl ts_rs::TS for FastStr {
+    type WithoutGenerics = Self;
+    fn name() -> String {
+        "string".to_owned()
+    }
+    fn inline() -> String {
+        <Self as ts_rs::TS>::name()
+    }
+    /// This function is expected to panic because primitive types cannot be flattened.
+    fn inline_flattened() -> String {
+        panic!("{} cannot be flattened", <Self as ts_rs::TS>::name())
+    }
+    /// This function is expected to panic because primitive types cannot be declared.
+    fn decl() -> String {
+        panic!("{} cannot be declared", <Self as ts_rs::TS>::name())
+    }
+    /// Same as `decl` if the type is not generic.
+    fn decl_concrete() -> String {
+        panic!("{} cannot be declared", <Self as ts_rs::TS>::name())
+    }
+}
+
+#[test]
+fn test_ts_rs() {
+    #[derive(ts_rs::TS)]
+    struct Nested {
+        #[allow(unused)]
+        #[ts(rename = "nested_id")]
+        id: FastStr,
+    }
+    #[derive(ts_rs::TS)]
+    struct Test {
+        #[allow(unused)]
+        #[ts(optional)]
+        id: Option<FastStr>,
+        #[allow(unused)]
+        #[ts(flatten)]
+        nested: Nested,
+    }
+
+    assert_eq!(
+        <Test as ts_rs::TS>::decl(),
+        "type Test = { id?: string, nested_id: string, };"
+    );
+}


### PR DESCRIPTION
This pr add support for [ts-rs](https://github.com/Aleph-Alpha/ts-rs).

```ts
#[derive(ts_rs::TS)]
struct Test {
	id: FastStr
}

assert_eq!(
	<Test as ts_rs::TS>::decl(),
	"type Test = { id: string, };"
);
```