### PR TITLE
feat: add GDB and LLDB extensions for debugging `FastStr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugger-example"
+version = "0.1.0"
+dependencies = [
+ "faststr",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ criterion = { version = "0.7", features = ["html_reports"] }
 sea-orm = { version = "1.1", features = ["macros", "mock"] }
 tokio = { version = "1", features = ["rt", "macros"] }
 
+[workspace]
+members = [".", "utils"]
+
 [[bench]]
 name = "faststr"
 harness = false

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,10 @@
+comment_width = 100
+edition = "2021"
+format_code_in_doc_comments = true
+format_strings = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+normalize_comments = true
+normalize_doc_attributes = true
+wrap_comments = true
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,11 @@ use alloc::{
     sync::Arc,
     vec::Vec,
 };
-use bytes::{Bytes, BytesMut};
 use core::{
     borrow::Borrow, cmp::Ordering, convert::Infallible, fmt, hash, iter, ops::Deref, str::FromStr,
 };
+
+use bytes::{Bytes, BytesMut};
 use simdutf8::basic::{from_utf8, Utf8Error};
 
 /// `FastStr` is a string type that try to avoid the cost of clone.
@@ -263,8 +264,8 @@ impl FastStr {
         self.0.into_string()
     }
 
-    /// If the inner repr of FastStr is a Bytes, then it will be deep cloned and returned as a new FastStr.
-    /// Otherwise, it will return a new FastStr with the same repr which has no cost.
+    /// If the inner repr of FastStr is a Bytes, then it will be deep cloned and returned as a new
+    /// FastStr. Otherwise, it will return a new FastStr with the same repr which has no cost.
     ///
     /// This is used to free the original memory of the Bytes.
     ///
@@ -812,7 +813,6 @@ pub mod ts_rs;
 
 #[cfg(feature = "sea-orm")]
 pub mod sea_orm;
-
 
 #[cfg(feature = "sqlx-postgres")]
 pub mod sqlx_postgres;

--- a/src/sea_orm.rs
+++ b/src/sea_orm.rs
@@ -53,11 +53,12 @@ impl sea_orm::sea_query::ValueType for FastStr {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use sea_orm::{
         entity::prelude::*, ActiveValue::Set, DerivePrimaryKey, MockDatabase, QueryTrait,
         TryFromU64 as _,
     };
+
+    use super::*;
 
     mod test_book {
         use super::*;
@@ -169,7 +170,8 @@ mod tests {
             .build(db);
         assert_eq!(
             select_query.to_string(),
-            "SELECT `test_book`.`id` FROM `test_book` INNER JOIN `test_page` ON `test_book`.`id` = `test_page`.`book_id` WHERE `test_book`.`id` = 'test string'"
+            "SELECT `test_book`.`id` FROM `test_book` INNER JOIN `test_page` ON `test_book`.`id` \
+             = `test_page`.`book_id` WHERE `test_book`.`id` = 'test string'"
         );
     }
 

--- a/src/sqlx_mysql.rs
+++ b/src/sqlx_mysql.rs
@@ -1,6 +1,7 @@
-use crate::FastStr;
 use sqlx::{encode::IsNull, error::BoxDynError, Decode, Encode, Type};
 use sqlx_mysql::{MySql, MySqlTypeInfo, MySqlValueRef};
+
+use crate::FastStr;
 
 impl Type<MySql> for FastStr {
     fn type_info() -> MySqlTypeInfo {

--- a/src/sqlx_postgres.rs
+++ b/src/sqlx_postgres.rs
@@ -1,8 +1,7 @@
-use crate::FastStr;
 use sqlx::{encode::IsNull, error::BoxDynError, Decode, Encode, Type};
-use sqlx_postgres::{Postgres, PgTypeInfo, PgValueRef};
+use sqlx_postgres::{PgTypeInfo, PgValueRef, Postgres};
 
-
+use crate::FastStr;
 
 impl Type<Postgres> for FastStr {
     fn type_info() -> PgTypeInfo {
@@ -32,9 +31,9 @@ impl<'r> Decode<'r, Postgres> for FastStr {
 
 impl Encode<'_, Postgres> for FastStr {
     fn encode_by_ref(
-            &self,
-            buf: &mut <Postgres as sqlx::Database>::ArgumentBuffer<'_>,
-        ) -> Result<IsNull, BoxDynError> {
+        &self,
+        buf: &mut <Postgres as sqlx::Database>::ArgumentBuffer<'_>,
+    ) -> Result<IsNull, BoxDynError> {
         <&str as Encode<Postgres>>::encode(self.as_str(), buf)
     }
     fn size_hint(&self) -> usize {

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "debugger-example"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+faststr = { path = ".." }

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,85 @@
+# Debugger Utilities
+
+## Usage
+
+For GDB, you can download the `faststr_gdb.py` and put it in your `.gdbinit`:
+
+```bash
+curl -fsSL https://github.com/volo-rs/faststr/raw/refs/heads/main/utils/faststr_gdb.py -o faststr_gdb.py
+echo "source $PWD/faststr_gdb.py" >> $HOME/.gdbinit
+```
+
+For LLDB, you can download the `faststr_lldb.py` and put it in your `.lldbinit`:
+
+```bash
+curl -fsSL https://github.com/volo-rs/faststr/raw/refs/heads/main/utils/faststr_lldb.py -o faststr_lldb.py
+echo "command script import $PWD/faststr_lldb.py" >> $HOME/.lldbinit
+```
+
+## Examples
+
+### GDB
+
+```
+$ cargo build -p debugger-example
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
+
+$ gdb ../target/debug/debugger-example
+(gdb) break main.rs:14
+Breakpoint 1 at 0xd10d: file utils/src/main.rs, line 14.
+(gdb) run
+Starting program: ../target/debug/debugger-example
+
+Breakpoint 1, debugger_example::main () at utils/src/main.rs:14
+14          println!("{s1:?}");
+(gdb) source faststr_gdb.py
+(gdb) print s1
+$1 = FastStr::Empty("")
+(gdb) print s2
+$2 = FastStr::Bytes("1145141919810114514191981011451419198101145141919810")
+(gdb) print s3
+$3 = FastStr::ArcStr("1145141919810114514191981011451419198101145141919810")
+(gdb) print s4
+$4 = FastStr::ArcString("1145141919810114514191981011451419198101145141919810")
+(gdb) print s5
+$5 = FastStr::StaticStr("1145141919810114514191981011451419198101145141919810")
+(gdb) print s6
+$6 = FastStr::Inline("Hello, World")
+```
+
+### LLDB
+
+```
+$ cargo build -p debugger-example
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
+
+$ lldb ../target/debug/debugger-example
+(lldb) target create "../target/debug/debugger-example"
+Current executable set to '../target/debug/debugger-example' (x86_64).
+(lldb) breakpoint set --file main.rs --line 14
+Breakpoint 1: 2 locations.
+(lldb) run
+Process 114514 launched: '../target/debug/debugger-example' (x86_64)
+Process 114514 stopped
+* thread #1, name = 'debugger-exampl', stop reason = breakpoint 1.1
+    frame #0: 0x000055555556110d debugger-example`debugger_example::main at main.rs:14:5
+   11       let s5 = FastStr::from_static_str(LONG_STRING);
+   12       let s6 = FastStr::from_string(SHORT_STRING.to_string());
+   13
+-> 14       println!("{s1:?}");
+   15       println!("{s2:?}");
+   16       println!("{s3:?}");
+   17       println!("{s4:?}");
+(lldb) print s1
+(faststr::FastStr) FastStr::Empty("")
+(lldb) print s2
+(faststr::FastStr) FastStr::Bytes("1145141919810114514191981011451419198101145141919810")
+(lldb) print s3
+(faststr::FastStr) FastStr::ArcStr("1145141919810114514191981011451419198101145141919810")
+(lldb) print s4
+(faststr::FastStr) FastStr::ArcString("1145141919810114514191981011451419198101145141919810")
+(lldb) print s5
+(faststr::FastStr) FastStr::StaticStr("1145141919810114514191981011451419198101145141919810")
+(lldb) print s6
+(faststr::FastStr) FastStr::Inline("Hello, World")
+```

--- a/utils/faststr_gdb.py
+++ b/utils/faststr_gdb.py
@@ -1,0 +1,112 @@
+import gdb
+
+VARIANT_NAMES = ['Empty', 'Bytes', 'ArcStr',
+                 'ArcString', 'StaticStr', 'Inline']
+
+
+class FastStrPrettyPrinter:
+    def __init__(self, valobj: gdb.Value):
+        repr_obj = valobj['__0']
+        inner = repr_obj[repr_obj.type.fields()[0]]
+        fields = inner.type.fields()
+        discr = int(inner[fields[0]]) + 1
+        field_name = fields[discr].name
+        assert field_name == VARIANT_NAMES[discr-1]
+        variant = inner[fields[discr]]
+
+        self._variant_name = field_name
+        self._display_string = ''
+        self._is_error = False
+
+        if discr == 1:
+            pass
+        elif discr == 2:
+            self._display_string = self._extract_bytes(variant)
+        elif discr == 3:
+            self._display_string = self._extract_arc_str(variant)
+        elif discr == 4:
+            self._display_string = self._extract_arc_string(variant)
+        elif discr == 5:
+            self._display_string = self._extract_static_str(variant)
+        elif discr == 6:
+            self._display_string = self._extract_inline(variant)
+        else:
+            self._display_string = '<Invalid FastStr>'
+            self._is_error = True
+
+    def _extract_bytes(self, variant: gdb.Value) -> str:
+        try:
+            bytes_obj = variant['__0']
+            length = int(bytes_obj['len'])
+            ptr = bytes_obj['ptr']
+            return ptr.string('utf-8', length=length)
+        except Exception as e:
+            self._is_error = True
+            return f'<Error reading Bytes: {e}>'
+
+    def _extract_arc_str(self, variant: gdb.Value) -> str:
+        try:
+            arc_obj = variant['__0']
+            non_null_ptr = arc_obj['ptr']
+            arc_inner_ptr = non_null_ptr['pointer']
+            data_ptr = arc_inner_ptr['data_ptr']
+            length = int(arc_inner_ptr['length'])
+            arc_inner = data_ptr.dereference()
+            str_data = arc_inner['data']
+            data = gdb.selected_inferior().read_memory(str_data.address, length)
+            return data.tobytes().decode('utf-8')
+        except Exception as e:
+            self._is_error = True
+            return f'<Error reading ArcStr: {e}>'
+
+    def _extract_arc_string(self, variant: gdb.Value) -> str:
+        try:
+            arc_obj = variant['__0']
+            non_null_ptr = arc_obj['ptr']
+            arc_inner_ptr = non_null_ptr['pointer']
+            arc_inner = arc_inner_ptr.dereference()
+            string_obj = arc_inner['data']
+            vec_obj = string_obj['vec']
+            length = int(vec_obj['len'])
+            buf = vec_obj['buf']
+            raw_vec_inner = buf['inner']
+            unique_ptr = raw_vec_inner['ptr']
+            non_null_u8_ptr = unique_ptr['pointer']
+            ptr = non_null_u8_ptr['pointer']
+            return ptr.string('utf-8', length=length)
+        except Exception as e:
+            self._is_error = True
+            return f'<Error reading ArcString: {e}>'
+
+    def _extract_static_str(self, variant: gdb.Value) -> str:
+        try:
+            str_ref = variant['__0']
+            length = int(str_ref['length'])
+            data_ptr = str_ref['data_ptr']
+            return data_ptr.string('utf-8', length=length)
+        except Exception as e:
+            self._is_error = True
+            return f'<Error reading StaticStr: {e}>'
+
+    def _extract_inline(self, variant: gdb.Value) -> str:
+        try:
+            length = int(variant['len'])
+            buf = variant['buf']
+            data = bytes([int(buf[i]) for i in range(length)])
+            return data.decode('utf-8')
+        except Exception as e:
+            self._is_error = True
+            return f'<Error reading Inline: {e}>'
+
+    def to_string(self) -> str:
+        return self._display_string if self._is_error else f'FastStr::{self._variant_name}("{self._display_string}")'
+
+
+def faststr_pretty_printer(valobj: gdb.Value):
+    type_name = str(valobj.type.strip_typedefs())
+    if type_name == 'faststr::FastStr':
+        return FastStrPrettyPrinter(valobj)
+    return None
+
+
+gdb.pretty_printers.append(faststr_pretty_printer)

--- a/utils/faststr_lldb.py
+++ b/utils/faststr_lldb.py
@@ -1,0 +1,148 @@
+import lldb
+import re
+
+VARIANT_NAMES = ['Empty', 'Bytes', 'ArcStr',
+                 'ArcString', 'StaticStr', 'Inline']
+
+
+class FastStrSyntheticProvider:
+    def __init__(self, valobj: lldb.SBValue, _internal_dict: dict):
+        # IMPORTANT: use non-synthetic value instead of formatted value by Rust official lldb plugin
+        self.valobj = valobj.GetNonSyntheticValue()
+        self.update()
+
+    def update(self):
+        repr = self.valobj.GetChildAtIndex(0)
+        variants = repr.GetChildMemberWithName('$variants$')
+        discr = variants.GetChildAtIndex(0).GetChildMemberWithName(
+            '$discr$').GetValueAsUnsigned()
+        variant = variants.GetChildAtIndex(discr)
+        variant_name = self._get_variant_name(variant)
+        assert variant_name == VARIANT_NAMES[discr]
+
+        self._variant_name = variant_name
+        self._display_string = ''
+        self._is_error = False
+
+        if variant_name == 'Empty':
+            self._display_string = ''
+        elif variant_name == 'Bytes':
+            self._display_string = self._extract_bytes(variant)
+        elif variant_name == 'ArcStr':
+            self._display_string = self._extract_arc_str(variant)
+        elif variant_name == 'ArcString':
+            self._display_string = self._extract_arc_string(variant)
+        elif variant_name == 'StaticStr':
+            self._display_string = self._extract_static_str(variant)
+        elif variant_name == 'Inline':
+            self._display_string = self._extract_inline(variant)
+        else:
+            self._display_string = '<Invalid FastStr>'
+            self._is_error = True
+
+    def _get_variant_name(self, variant: lldb.SBValue):
+        full_name = variant.GetType().GetName()
+        # faststr::Repr::faststr::Repr$Inner::Empty$Variant
+        return re.match('^([a-zA-Z:]+)\\$Inner::([a-zA-Z]+)\\$Variant$', full_name).group(2)
+
+    def _extract_bytes(self, variant: lldb.SBValue) -> str:
+        bytes_obj = variant.GetChildMemberWithName(
+            'value').GetChildMemberWithName('__0')
+        ptr = bytes_obj.GetChildMemberWithName('ptr').GetValueAsUnsigned()
+        length = bytes_obj.GetChildMemberWithName('len').GetValueAsUnsigned()
+        error = lldb.SBError()
+        data = variant.GetProcess().ReadMemory(ptr, length, error)
+        if error.Success():
+            return data.decode('utf-8')
+        else:
+            self._is_error = True
+            return f'<Error reading Bytes: {error.GetCString()}>'
+
+    def _extract_arc_str(self, variant: lldb.SBValue) -> str:
+        # Arc<str>
+        arc_str = variant.GetChildMemberWithName(
+            'value').GetChildMemberWithName('__0')
+        ptr = arc_str.GetChildMemberWithName('ptr')
+        # ArcInner
+        pointer = ptr.GetChildMemberWithName('pointer')
+        # str
+        data_ptr = pointer.GetChildMemberWithName('data_ptr')
+        length = pointer.GetChildMemberWithName('length').GetValueAsUnsigned()
+        data = data_ptr.GetChildMemberWithName('data')
+        error = lldb.SBError()
+        data = variant.GetProcess().ReadMemory(
+            data.AddressOf().GetValueAsUnsigned(), length, error)
+        if error.Success():
+            return data.decode('utf-8')
+        else:
+            self._is_error = True
+            return f'<Error reading ArcStr: {error.GetCString()}>'
+
+    def _extract_arc_string(self, variant: lldb.SBValue) -> str:
+        # Arc<String>
+        arc_str = variant.GetChildMemberWithName(
+            'value').GetChildMemberWithName('__0')
+        ptr = arc_str.GetChildMemberWithName('ptr')
+        # ArcInner
+        arc_inner = ptr.GetChildMemberWithName('pointer')
+        # String
+        data = arc_inner.GetChildMemberWithName('data')
+        # inner Vec<u8>
+        vec = data.GetChildMemberWithName('vec')
+        pointer = vec.GetChildMemberWithName('buf').GetChildMemberWithName('inner').GetChildMemberWithName(
+            'ptr').GetChildMemberWithName('pointer').GetChildMemberWithName('pointer')
+        length = vec.GetChildMemberWithName('len').GetValueAsUnsigned()
+        error = lldb.SBError()
+        data = variant.GetProcess().ReadMemory(
+            pointer.GetValueAsUnsigned(), length, error)
+        if error.Success():
+            return data.decode('utf-8')
+        else:
+            self._is_error = True
+            return f'<Error reading ArcString: {error.GetCString()}>'
+
+    def _extract_static_str(self, variant: lldb.SBValue) -> str:
+        # &'static str
+        static_str = variant.GetChildMemberWithName(
+            'value').GetChildMemberWithName('__0')
+        data_ptr = static_str.GetChildMemberWithName('data_ptr')
+        length = static_str.GetChildMemberWithName(
+            'length').GetValueAsUnsigned()
+        error = lldb.SBError()
+        data = variant.GetProcess().ReadMemory(
+            data_ptr.GetValueAsUnsigned(), length, error)
+        if error.Success():
+            return data.decode('utf-8')
+        else:
+            self._is_error = True
+            return f'<Error reading StaticStr: {error.GetCString()}>'
+
+    def _extract_inline(self, variant: lldb.SBValue) -> str:
+        # inline
+        inline = variant.GetChildMemberWithName('value')
+        buf = inline.GetChildMemberWithName('buf')
+        length = inline.GetChildMemberWithName('len').GetValueAsUnsigned()
+        error = lldb.SBError()
+        data = variant.GetProcess().ReadMemory(
+            buf.AddressOf().GetValueAsUnsigned(), length, error)
+        if error.Success():
+            return data.decode('utf-8')
+        else:
+            self._is_error = True
+            return f'<Error reading Inline: {error.GetCString()}>'
+
+    def to_string(self) -> str:
+        return self._display_string if self._is_error else f'FastStr::{self._variant_name}("{self._display_string}")'
+
+
+def FastStrSummaryProvider(valobj: lldb.SBValue, internal_dict: dict) -> str:
+    return FastStrSyntheticProvider(valobj, internal_dict).to_string()
+
+
+def __lldb_init_module(debugger, internal_dict):
+    debugger.HandleCommand(
+        'type synthetic add -F faststr_lldb.VSCodeFastStrSyntheticProvider faststr::FastStr'
+    )
+    debugger.HandleCommand(
+        'type summary add -F faststr_lldb.FastStrSummaryProvider faststr::FastStr'
+    )

--- a/utils/src/main.rs
+++ b/utils/src/main.rs
@@ -1,0 +1,20 @@
+use faststr::FastStr;
+
+const LONG_STRING: &str = "1145141919810114514191981011451419198101145141919810";
+const SHORT_STRING: &str = "Hello, World";
+
+fn main() {
+    let s1 = FastStr::empty();
+    let s2 = FastStr::from_string(LONG_STRING.to_string());
+    let s3 = FastStr::from_arc_str(std::sync::Arc::from(LONG_STRING));
+    let s4 = FastStr::from_arc_string(std::sync::Arc::new(LONG_STRING.to_string()).clone());
+    let s5 = FastStr::from_static_str(LONG_STRING);
+    let s6 = FastStr::from_string(SHORT_STRING.to_string());
+
+    println!("{s1:?}");
+    println!("{s2:?}");
+    println!("{s3:?}");
+    println!("{s4:?}");
+    println!("{s5:?}");
+    println!("{s6:?}");
+}


### PR DESCRIPTION
## Motivation

In GDB and LLDB, it's not possible to inspect the value of `FastStr`.

## Solution

This PR adds two extensions to GDB and LLDB so that we can inspect the value of `FastStr` in GDB and LLDB (and also in CodeLLDB in VS Code).